### PR TITLE
Node compatibility: adding semantic `getItem` and `setItem` 

### DIFF
--- a/lib/localStorage.js
+++ b/lib/localStorage.js
@@ -18,14 +18,14 @@ class LocalStorageStore extends ObservableStore {
 
   // read from persistence
   _getState () {
-    const serialized = global.localStorage[this._storageKey]
+    const serialized = global.localStorage.getItem(this._storageKey)
     return serialized ? JSON.parse(serialized) : undefined
   }
 
   // write to persistence
   _putState (newState) {
     const serialized = JSON.stringify(newState)
-    return global.localStorage[this._storageKey] = serialized
+    return global.localStorage.setItem(this._storageKey, serialized)
   }
 
 }


### PR DESCRIPTION
Great package you wrote here -- thank you for sharing it.

For people who are maintaining a node-stack for testing, they may be using a stand-in for LocalStorage, like https://github.com/lmaccherone/node-localstorage. That package doesn't accept the short-hand key getters/setters, which is why I made this change. Seems to be working.

Cheers!

