### PR TITLE
Allow destroying of an ObsStoreStream

### DIFF
--- a/lib/asStream.js
+++ b/lib/asStream.js
@@ -21,6 +21,8 @@ class ObsStoreStream extends DuplexStream {
     })
     // dont buffer outgoing updates
     this.resume()
+    // save handler so we can unsubscribe later
+    this.handler = (state) => this.push(state)
     // subscribe to obsStore changes
     this.obsStore = obsStore
     this.obsStore.subscribe((state) => this.push(state))
@@ -41,6 +43,12 @@ class ObsStoreStream extends DuplexStream {
 
   // noop - outgoing stream is asking us if we have data we arent giving it
   _read (size) { }
+  
+  // unsubscribe from event emitter
+  _destroy (err, callback) {
+    this.obsStore.unsubscribe(this.handler);
+    super._destroy(err, callback)
+  }
 
 }
 


### PR DESCRIPTION
Without this, any application which creates numerous streams on a single event emitter has no way of unsubscribing from it which causes a memory leak.